### PR TITLE
Add ProGuard to Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,27 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.wvengen</groupId>
+                <artifactId>proguard-maven-plugin</artifactId>
+                <executions>
+                   <execution>
+                       <phase>package</phase>
+                       <goals>
+                           <goal>proguard</goal>
+                       </goals>
+                   </execution>
+                </executions>
+                <configuration>
+                    <proguardVersion>7.0.1</proguardVersion>
+                    <options>
+                        <option>-dontobfuscate</option>
+                    </options>
+                    <libs>
+                        <lib>${java.home}/jmods/java.base.jmod</lib>
+                    </libs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.0.0-M1</version>


### PR DESCRIPTION
# Changes made in this Pull Request
Added ProGuard to Maven build.

# Reason of the above changes are
Note: This only for shrinking & optimizing, NOT for obfuscating.

# Other information about this Pull Request
This also fixes the Maven Shade Plugin build warning. That warning was the actual reason we'll considering to switch ProGuard anyway. There is a PR fixes that but there have been 15 days and it has not yet been merged. Switching to Gradle is not a goal at this point, but maybe in future.