### PR TITLE
Use hash set instead of array list for performance

### DIFF
--- a/src/main/java/com/lifemcserver/bytecodeversionanalyzer/BytecodeVersionAnalyzer.java
+++ b/src/main/java/com/lifemcserver/bytecodeversionanalyzer/BytecodeVersionAnalyzer.java
@@ -964,7 +964,7 @@ final class BytecodeVersionAnalyzer {
      */
     private static final class JarEntryVersionConsumer implements Consumer<JarEntry> {
         private final Map<String, ClassFileVersion> classes = new HashMap<>();
-        private final List<String> entries = new ArrayList<>();
+        private final Set<String> entries = new HashSet<>();
 
         private final JarFile jar;
 


### PR DESCRIPTION
# Changes made in this Pull Request
Changed duplicate entry tracker to use HashSet instead of ArrayList for performance.

# Reason of the above changes are
We only use the contains and add methods, we are not adding duplicate entries, and we use String, each String should have unique hash code. So, we can use HashSet instead.

# Other information about this Pull Request
By using HashSet instead of ArrayList, we can gain a performance improvement.

ArrayList#contains compute time is O(n), where as HashSet's one is O(1). So, the more entries on the ArrayList, the more time it will take for the contains method.