### PR TITLE
Update to Java 16

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,10 +34,10 @@ jobs:
                 with:
                     fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
-            -   name: Set up JDK 15
+            -   name: Set up JDK 16
                 uses: actions/setup-java@v1.4.3
                 with:
-                    java-version: 15.0.2
+                    java-version: 16
 
             -   name: Cache SonarCloud packages
                 uses: actions/cache@v2.1.4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,7 @@ jobs:
                 uses: actions/setup-java@v2.0.0
                 with:
                     distribution: 'adopt'
-                    java-version: 16
+                    java-version: 16.0.1
 
             -   name: Cache SonarCloud packages
                 uses: actions/cache@v2.1.5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
                     fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
             -   name: Set up JDK 16
-                uses: actions/setup-java@v1.4.3
+                uses: actions/setup-java@v2.0.0
                 with:
                     distribution: 'adopt'
                     java-version: 16

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,6 +3,6 @@ queries:
 extraction:
     java:
         index:
-            java_version: 15
+            java_version: 16
             build_command:
                 - ./mvnw clean verify --threads 1C --batch-mode --errors

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
                     <forceJavacCompilerUse>false</forceJavacCompilerUse>
                     <!--<compilerId>eclipse</compilerId>-->
                     <compilerId>javac</compilerId>
-                    <compilerVersion>15</compilerVersion>
+                    <compilerVersion>16</compilerVersion>
                     <compilerArgs>
                         <!--<arg>-properties</arg>
                         <arg>.settings/org.eclipse.jdt.core.prefs</arg>-->
@@ -301,13 +301,13 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>compile-java-15</id>
+                        <id>compile-java-16</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <release>15</release>
+                            <release>16</release>
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
 


### PR DESCRIPTION
# Changes made in this Pull Request
Updates the Project to use Java 16:
- Makes GH Actions build use Java 16.
- Makes LGTM build use Java 16.

- Makes Maven use Java 16 compiler version.
- Makes Maven compile into Java 16 with cross compile/multi release.

# Reason of the above changes are
Java 16 is out and Java 15 will be EOL.

# Other information about this Pull Request
Should be merged after Java 15 is removed from Oracle site as a downloadable JDK and Java 16 being finalized. It is already available for download and it is GA right now but it is same as the last EA build.